### PR TITLE
Add aria-multiselectable="true" to multiselect treeview

### DIFF
--- a/packages/react/src/components/TreeView/TreeView.js
+++ b/packages/react/src/components/TreeView/TreeView.js
@@ -164,7 +164,8 @@ export default function TreeView({
         className={treeClasses}
         onKeyDown={handleKeyDown}
         ref={treeRootRef}
-        role="tree">
+        role="tree"
+        aria-multiselectable={multiselect}>
         {nodesWithProps}
       </ul>
     </>


### PR DESCRIPTION
Multiselect treeview needs to have aria-multiselectable="true" in order to work properly with screen readers.
@emyarod 