### PR TITLE
fix(ComboBox): don't call `onInputChange` needlessly

### DIFF
--- a/packages/react/src/components/ComboBox/ComboBox.js
+++ b/packages/react/src/components/ComboBox/ComboBox.js
@@ -150,7 +150,7 @@ const ComboBox = (props) => {
     if (onInputChange) {
       onInputChange(inputValue);
     }
-  });
+  }, [inputValue]);
 
   const handleSelectionClear = () => {
     if (textInput?.current) {


### PR DESCRIPTION
Currently `onInputChange` get triggered with every render.

This change will only call `onInputChange` when `inputValue` changes.
